### PR TITLE
 Added style tag to the description to see the entered linebreaks by user

### DIFF
--- a/client/components/ui/Meal/Meal.less
+++ b/client/components/ui/Meal/Meal.less
@@ -80,7 +80,7 @@
 
         .description {
             margin: 10px 0;
-            style="white-space:pre-wrap";
+            white-space: pre-wrap;
         }
     }
 

--- a/client/components/ui/Meal/Meal.less
+++ b/client/components/ui/Meal/Meal.less
@@ -80,6 +80,7 @@
 
         .description {
             margin: 10px 0;
+            style="white-space:pre-wrap";
         }
     }
 


### PR DESCRIPTION
For example: "Männer 10 Euro Frauen auf Anfrage" contains no comma, because it was entered with a linebreak that is not shown in the storefront